### PR TITLE
Fix compile errors related to missing Control.Applicative imports

### DIFF
--- a/src/Text/Numeral/BigNum.hs
+++ b/src/Text/Numeral/BigNum.hs
@@ -19,6 +19,7 @@ module Text.Numeral.BigNum
 -------------------------------------------------------------------------------
 
 import "base" Data.Function ( fix )
+import "base" Control.Applicative ( (<$>) )
 import "base" Data.Monoid ( (<>) )
 import qualified "containers" Data.Map as M
 import "this" Text.Numeral

--- a/src/Text/Numeral/Language/NLD.hs
+++ b/src/Text/Numeral/Language/NLD.hs
@@ -31,6 +31,7 @@ module Text.Numeral.Language.NLD
 
 import "base" Data.Function ( fix )
 import "base" Data.Monoid ( (<>) )
+import "base" Control.Applicative ( pure )
 import qualified "containers" Data.Map as M
 import           "this" Text.Numeral hiding ( partitive, multiplicative )
 import qualified "this" Text.Numeral.BigNum  as BN

--- a/src/Text/Numeral/Render.hs
+++ b/src/Text/Numeral/Render.hs
@@ -19,6 +19,7 @@ module Text.Numeral.Render
 -------------------------------------------------------------------------------
 
 import "base" Data.Monoid ( (<>) )
+import "base" Control.Applicative ( (<$>) )
 import "text" Data.Text ( Text )
 import "this" Text.Numeral.Exp ( Exp(..), Side(L, R) )
 import "this" Text.Numeral.Grammar ( Inflection(..) )


### PR DESCRIPTION
I was trying to compile the current numerals git code on Ubuntu 15.10 due to #15 . I noticed that there are three Control.Applicative imports (`<$>` twice and `pure` missing). This pull request fixes that.
