### PR TITLE
Fixed incorrect ordinal representation (CRO)

### DIFF
--- a/src-test/Text/Numeral/Language/CRO/TestData.hs
+++ b/src-test/Text/Numeral/Language/CRO/TestData.hs
@@ -110,6 +110,7 @@ cardinals =
       , (17999, "sedamnaest tisuća devetsto devedeset devet")
       , (25358, "dvadeset pet tisuća tristo pedeset osam")
       , (105358, "sto pet tisuća tristo pedeset osam")
+      , (246912, "dvjesto četrdeset šest tisuća devetsto dvanaest")
       ]
     )
   ]

--- a/src/Text/Numeral/Language/CRO.hs
+++ b/src/Text/Numeral/Language/CRO.hs
@@ -108,7 +108,7 @@ cardinalRepr neg f =
         M.fromList
         [ (0, const "nula")
         , (1, ten "jedan" "jeda" "jedan")
-        , (2, const "dva")
+        , (2, hun "dva" "dva" "dvje" "dva")
         , (3, const "tri")
         , (4, ten "četiri" "četr" "četr")
         , (5, ten "pet" "pet" "pe")


### PR DESCRIPTION
Number 2 has specific set of rules in Croatian language when referenced in
hundred context (e.g. 205). One additional rule was added which captures that
edge case.