### PR TITLE
Fix examples in README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -39,7 +39,7 @@ Inflections are not concrete types, but polymorphic parameters
 constrained by type classes. Use the reified inflection type provided
 by the `numerals-base` package to get a concrete value:
 
-    >>> import Text.Numeral.Grammar.Reified ( defaultInflection )
+    >>> import Text.Numeral.Grammar ( defaultInflection )
 
 ### Numeral structure
 
@@ -49,19 +49,23 @@ module.
 
 ### Examples
 
-The use of this package is best understood with some examples. First
-some English number names, both British and US variants:
+The use of this package is best understood with some examples. Firstly, prepare to use Numerals by importing required packages:
+    
+    >>> import Data.Text
+    >>> import Text.Numeral.Grammar ( defaultInflection )
 
-    >>> import qualified Text.Numeral.Language.EN as EN
-    >>> EN.uk_cardinal defaultInflection 123 :: Maybe Text
+Let's start with some English number names, both British and US variants:
+
+    >>> import qualified Text.Numeral.Language.ENG as ENG
+    >>> ENG.gb_cardinal defaultInflection 123 :: Maybe Text
     Just "one hundred and twenty-three"
-    >>> EN.us_cardinal defaultInflection (10^50 + 42) :: Maybe Text
+    >>> ENG.us_cardinal defaultInflection (10^50 + 42) :: Maybe Text
     Just "one hundred quindecillion forty-two"
 
 French, which contains some traces of a base 20 system:
 
-    >>> import qualified Text.Numeral.Language.FR as FR
-    >>> FR.cardinal defaultInflection (-99) :: Maybe Text
+    >>> import qualified Text.Numeral.Language.FRA as FRA
+    >>> FRA.cardinal defaultInflection (-99) :: Maybe Text
     Just "moins quatre-vingt-dix-neuf"
 
 Conversions can fail. Alamblak, a language spoken by a few people in
@@ -77,42 +81,39 @@ characters or transcribed to the Latin script using Pinyin.
 
 Traditional Chinese characters:
 
-    >>> import qualified Text.Numeral.Language.ZH as ZH
-    >>> ZH.trad_cardinal defaultInflection 123456 :: Maybe Text
+    >>> import qualified Text.Numeral.Language.ZHO as ZHO
+    >>> ZHO.trad_cardinal defaultInflection 123456 :: Maybe Text
     Just "十二萬三千四百五十六"
 
 Simplified characters for use in financial contexts:
 
-    >>> ZH.finance_simpl_cardinal defaultInflection 123456 :: Maybe Text
+    >>> ZHO.finance_simpl_cardinal defaultInflection 123456 :: Maybe Text
     Just "拾贰万参仟肆伯伍拾陆"
 
 Transcribed using Pinyin:
 
-    >>> ZH.pinyin_cardinal defaultInflection 123456 :: Maybe Text
+    >>> ZHO.pinyin_cardinal defaultInflection 123456 :: Maybe Text
     Just "shíèrwàn sānqiān sìbǎi wǔshí liù"
 
 In Spanish the word for the quantity '1' differs based on its
 gender. We convey the gender via the inflection parameter:
 
     >>> import Text.Numeral.Grammar ( masculine, feminine, neuter )
-    >>> import Text.Numeral.Grammar.Reified ( defaultInflection )
-    >>> import qualified Text.Numeral.Language.ES as ES
-    >>> ES.cardinal (masculine defaultInflection) 1 :: Maybe Text
+    >>> import qualified Text.Numeral.Language.SPA as SPA
+    >>> SPA.cardinal (masculine defaultInflection) 1 :: Maybe Text
     Just "un"
-    >>> ES.cardinal (feminine defaultInflection) 1 :: Maybe Text
+    >>> SPA.cardinal (feminine defaultInflection) 1 :: Maybe Text
     Just "una"
-    >>> ES.cardinal (neuter defaultInflection) 1 :: Maybe Text
+    >>> SPA.cardinal (neuter defaultInflection) 1 :: Maybe Text
     Just "uno"
 
 Using the `struct` functions you can see the grammatical structure of
 number names. Because the results of these functions are polymorphic
 you need to specify a specific type.
 
-    >>> import qualified Text.Numeral.Language.NL as NL
-    >>> NL.struct 123 :: Integer
-    123
-    >>> import Text.Numeral.Exp.Reified ( Exp, showExp )
-    >>> showExp (NL.struct 123 :: Exp i)
+    >>> import qualified Text.Numeral.Language.NLD as NLD
+    >>> import Text.Numeral.Exp ( Exp, showExp )
+    >>> showExp (NLD.struct 123)
     Add (Lit 100) (Add (Lit 3) (Mul (Lit 2) (Lit 10)))
 
 Compare with:


### PR DESCRIPTION
This PR aims to solve problems with not working examples in README.markdown, mainly by finding current names of old modules and functions.

I hope that this PR will be accepted. If you have any questions regarding my PR, I am willing to answer them all.

Notes:
1. Since example `NLD.struct 123 :: Integer` does not seem to work (types mismatch error), I decided to remove it.