### PR TITLE
Fix residual cases of 2-letter alpha codes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -52,16 +52,16 @@ module.
 The use of this package is best understood with some examples. First
 some English number names, both British and US variants:
 
-    >>> import qualified Text.Numeral.Language.EN as EN
-    >>> EN.uk_cardinal defaultInflection 123 :: Maybe Text
+    >>> import qualified Text.Numeral.Language.ENG as ENG
+    >>> ENG.gb_cardinal defaultInflection 123 :: Maybe Text
     Just "one hundred and twenty-three"
-    >>> EN.us_cardinal defaultInflection (10^50 + 42) :: Maybe Text
+    >>> ENG.us_cardinal defaultInflection (10^50 + 42) :: Maybe Text
     Just "one hundred quindecillion forty-two"
 
 French, which contains some traces of a base 20 system:
 
-    >>> import qualified Text.Numeral.Language.FR as FR
-    >>> FR.cardinal defaultInflection (-99) :: Maybe Text
+    >>> import qualified Text.Numeral.Language.FRA as FRA
+    >>> FRA.cardinal defaultInflection (-99) :: Maybe Text
     Just "moins quatre-vingt-dix-neuf"
 
 Conversions can fail. Alamblak, a language spoken by a few people in
@@ -77,47 +77,45 @@ characters or transcribed to the Latin script using Pinyin.
 
 Traditional Chinese characters:
 
-    >>> import qualified Text.Numeral.Language.ZH as ZH
-    >>> ZH.trad_cardinal defaultInflection 123456 :: Maybe Text
+    >>> import qualified Text.Numeral.Language.ZHO as ZHO
+    >>> ZHO.trad_cardinal defaultInflection 123456 :: Maybe Text
     Just "十二萬三千四百五十六"
 
 Simplified characters for use in financial contexts:
 
-    >>> ZH.finance_simpl_cardinal defaultInflection 123456 :: Maybe Text
+    >>> ZHO.finance_simpl_cardinal defaultInflection 123456 :: Maybe Text
     Just "拾贰万参仟肆伯伍拾陆"
 
 Transcribed using Pinyin:
 
-    >>> ZH.pinyin_cardinal defaultInflection 123456 :: Maybe Text
+    >>> ZHO.pinyin_cardinal defaultInflection 123456 :: Maybe Texto
     Just "shíèrwàn sānqiān sìbǎi wǔshí liù"
 
 In Spanish the word for the quantity '1' differs based on its
 gender. We convey the gender via the inflection parameter:
 
     >>> import Text.Numeral.Grammar ( masculine, feminine, neuter )
-    >>> import Text.Numeral.Grammar.Reified ( defaultInflection )
-    >>> import qualified Text.Numeral.Language.ES as ES
-    >>> ES.cardinal (masculine defaultInflection) 1 :: Maybe Text
+    >>> import Text.Numeral.Grammar ( defaultInflection )
+    >>> import qualified Text.Numeral.Language.SPA as SPA
+    >>> SPA.cardinal (masculine defaultInflection) 1 :: Maybe Text
     Just "un"
-    >>> ES.cardinal (feminine defaultInflection) 1 :: Maybe Text
+    >>> SPA.cardinal (feminine defaultInflection) 1 :: Maybe Text
     Just "una"
-    >>> ES.cardinal (neuter defaultInflection) 1 :: Maybe Text
+    >>> SPA.cardinal (neuter defaultInflection) 1 :: Maybe Text
     Just "uno"
 
 Using the `struct` functions you can see the grammatical structure of
 number names. Because the results of these functions are polymorphic
 you need to specify a specific type.
 
-    >>> import qualified Text.Numeral.Language.NL as NL
-    >>> NL.struct 123 :: Integer
-    123
-    >>> import Text.Numeral.Exp.Reified ( Exp, showExp )
-    >>> showExp (NL.struct 123 :: Exp i)
+    >>> import qualified Text.Numeral.Language.NLD as NLD
+    >>> import Text.Numeral.Exp ( Exp, showExp )
+    >>> showExp (NLD.struct 123 :: Exp
     Add (Lit 100) (Add (Lit 3) (Mul (Lit 2) (Lit 10)))
 
 Compare with:
 
-    >>> NL.cardinal defaultInflection 123 :: Maybe Text
+    >>> NLD.cardinal defaultInflection 123 :: Maybe Text
     Just "honderddrieëntwintig"
 
 100 (honderd) + (3 (drie) + (ën) 2 (twin) * 10 (tig))

--- a/src-test/Text/Numeral/Language/DAN/TestData.hs
+++ b/src-test/Text/Numeral/Language/DAN/TestData.hs
@@ -10,7 +10,7 @@
 [@English name@]    Danish
 -}
 
-module Text.Numeral.Language.DA.TestData (cardinals) where
+module Text.Numeral.Language.DAN.TestData (cardinals) where
 
 
 --------------------------------------------------------------------------------

--- a/src/Text/Numeral.hs
+++ b/src/Text/Numeral.hs
@@ -67,16 +67,16 @@ such as case, gender or number.
 The use of this package is best understood with some examples. First some
 English number names, both British and US variants:
 
->>> import qualified Text.Numeral.Language.EN as EN
->>> EN.uk_cardinal defaultInflection 123 :: Maybe Text
+>>> import qualified Text.Numeral.Language.ENG as ENG
+>>> ENG.gb_cardinal defaultInflection 123 :: Maybe Text
 Just "one hundred and twenty-three"
->>> EN.us_cardinal defaultInflection (10^50 + 42) :: Maybe Text
+>>> ENG.us_cardinal defaultInflection (10^50 + 42) :: Maybe Text
 Just "one hundred quindecillion forty-two"
 
 French, which contains some traces of a base 20 system:
 
->>> import qualified Text.Numeral.Language.FR as FR
->>> FR.cardinal defaultInflection (-99) :: Maybe Text
+>>> import qualified Text.Numeral.Language.FRA as FRA
+>>> FRA.cardinal defaultInflection (-99) :: Maybe Text
 Just "moins quatre-vingt-dix-neuf"
 
 Conversions can fail. Alamblak, a language spoken by a few people in Papua New
@@ -92,34 +92,32 @@ the Latin script using Pinyin.
 
 Traditional Chinese characters:
 
->>> import qualified Text.Numeral.Language.ZH as ZH
->>> ZH.trad_cardinal defaultInflection 123456 :: Maybe Text
+>>> import qualified Text.Numeral.Language.ZHO as ZHO
+>>> ZHO.trad_cardinal defaultInflection 123456 :: Maybe Text
 Just "十二萬三千四百五十六"
 
 Simplified characters for use in financial contexts:
 
->>> ZH.finance_simpl_cardinal defaultInflection 123456 :: Maybe Text
+>>> ZHO.finance_simpl_cardinal defaultInflection 123456 :: Maybe Text
 Just "拾贰万参仟肆伯伍拾陆"
 
 Transcribed using Pinyin:
 
->>> ZH.pinyin_cardinal defaultInflection 123456 :: Maybe Text
+>>> ZHO.pinyin_cardinal defaultInflection 123456 :: Maybe Text
 Just "shíèrwàn sānqiān sìbǎi wǔshí liù"
 
 Using the 'struct' functions you can see the grammatical structure of number
 names. Because the results of these functions are polymorphic you need to
 specify a specific type.
 
->>> import qualified Text.Numeral.Language.NL as NL
->>> NL.struct 123 :: Integer
-123
+>>> import qualified Text.Numeral.Language.NLD as NLD
 >>> import Text.Numeral
->>> NL.struct 123 :: Exp
+>>> NLD.struct 123 :: Exp
 Add (Lit 100) (Add (Lit 3) (Mul (Lit 2) (Lit 10)))
 
 Compare with:
 
->>> NL.cardinal defaultInflection 123 :: Maybe Text
+>>> NLD.cardinal defaultInflection 123 :: Maybe Text
 Just "honderddrieëntwintig"
 
 100 (honderd) + (3 (drie) + (ën) 2 (twin) * 10 (tig))

--- a/src/Text/Numeral/Debug.hs
+++ b/src/Text/Numeral/Debug.hs
@@ -22,28 +22,28 @@ import Text.Numeral
 import Text.Numeral.Misc
 import qualified Text.Numeral.Language.AMP as AMP
 import qualified Text.Numeral.Language.CHN as CHN
-import qualified Text.Numeral.Language.DE  as DE
-import qualified Text.Numeral.Language.EN  as EN
-import qualified Text.Numeral.Language.EO  as EO
-import qualified Text.Numeral.Language.ES  as ES
-import qualified Text.Numeral.Language.FR  as FR
-import qualified Text.Numeral.Language.GV  as GV
-import qualified Text.Numeral.Language.IT  as IT
-import qualified Text.Numeral.Language.JA  as JA
-import qualified Text.Numeral.Language.LA  as LA
-import qualified Text.Numeral.Language.MG  as MG
-import qualified Text.Numeral.Language.NL  as NL
-import qualified Text.Numeral.Language.NO  as NO
+import qualified Text.Numeral.Language.DEU  as DEU
+import qualified Text.Numeral.Language.ENG  as ENG
+import qualified Text.Numeral.Language.EPO  as EPO
+import qualified Text.Numeral.Language.SPA  as SPA
+import qualified Text.Numeral.Language.FRA  as FRA
+import qualified Text.Numeral.Language.GLV  as GLV
+import qualified Text.Numeral.Language.ITA  as ITA
+import qualified Text.Numeral.Language.JPN  as JPN
+import qualified Text.Numeral.Language.LAT  as LAT
+import qualified Text.Numeral.Language.MLG  as MLG
+import qualified Text.Numeral.Language.NLD  as NLD
+import qualified Text.Numeral.Language.NOR  as NOR
 import qualified Text.Numeral.Language.NQM as NQM
-import qualified Text.Numeral.Language.OJ  as OJ
+import qualified Text.Numeral.Language.OJI  as OJI
 import qualified Text.Numeral.Language.PAA as PAA
-import qualified Text.Numeral.Language.PT  as PT
-import qualified Text.Numeral.Language.RU  as RU
-import qualified Text.Numeral.Language.SV  as SV
-import qualified Text.Numeral.Language.TR  as TR
-import qualified Text.Numeral.Language.WO  as WO
+import qualified Text.Numeral.Language.POR  as POR
+import qualified Text.Numeral.Language.RUS  as RUS
+import qualified Text.Numeral.Language.SWE  as SWE
+import qualified Text.Numeral.Language.TUR  as TUR
+import qualified Text.Numeral.Language.WOL  as WOL
 import qualified Text.Numeral.Language.YOR as YOR
-import qualified Text.Numeral.Language.ZH  as ZH
+import qualified Text.Numeral.Language.ZHO  as ZHO
 
 import qualified Text.Numeral.BigNum as BN
 

--- a/src/Text/Numeral/Language/DAN.hs
+++ b/src/Text/Numeral/Language/DAN.hs
@@ -16,7 +16,7 @@
 [@English name@]    Danish
 -}
 
-module Text.Numeral.Language.DA
+module Text.Numeral.Language.DAN
     ( -- * Language entry
       entry
       -- * Conversions
@@ -47,7 +47,7 @@ import "this" Text.Numeral.Entry
 
 
 -------------------------------------------------------------------------------
--- DA
+-- DAN
 -------------------------------------------------------------------------------
 
 entry :: Entry


### PR DESCRIPTION
There were a number of cases, including in documentation, where 2-letter language codes were still used even though the library interface has changed to 3-letter codes. This patch fixes all those cases I could find.

It also:
1. Fixes a case of using `uk_cardinal` where `gb_cardinal` should have been used.
1. Removes the `Exp i` type parameter from an example.
1. Removes the example showing the use of `struct` as `:: Integer`, since that's no longer possible.