### PR TITLE
Bump to version 0.4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .hpc
 dist
+dist-newstyle

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,6 +1,16 @@
 Changelog for numerals
 ======================
 
+0.4.2
+-----
+
+*Sat Jul 13 2024*
+
+- Removed dependency upper bounds for easier maintenance.
+- Removed unicode symbols from Debug module.
+- Added Igbo (IBO) cardinals and ordinals.
+- Default to GHC-8.2.2 when building with Nix.
+- Fix test build errors.
 
 0.4.1
 -----

--- a/numerals.cabal
+++ b/numerals.cabal
@@ -1,5 +1,5 @@
 name:          numerals
-version:       0.4.1
+version:       0.4.2
 cabal-version: >= 1.9.2
 build-type:    Simple
 stability:     experimental

--- a/src-test/Text/Numeral/Language/FIN/TestData.hs
+++ b/src-test/Text/Numeral/Language/FIN/TestData.hs
@@ -23,7 +23,7 @@ module Text.Numeral.Language.FIN.TestData
 --------------------------------------------------------------------------------
 
 import "base" Data.Function ( ($) )
-import "base" Prelude     ( Integral, (+) )
+import "base" Prelude     ( Integral, (+), (*) )
 import "numerals" Text.Numeral.Grammar
 import "numerals" Text.Numeral.Grammar ( defaultInflection )
 import "numerals" Text.Numeral.Misc ( dec )

--- a/src-test/Text/Numeral/Language/LIT/TestData.hs
+++ b/src-test/Text/Numeral/Language/LIT/TestData.hs
@@ -16,7 +16,7 @@ module Text.Numeral.Language.LIT.TestData (cardinals) where
 -- Imports
 --------------------------------------------------------------------------------
 
-import "base" Prelude ( Integral, (+) )
+import "base" Prelude ( Integral, (+), (*) )
 import "numerals" Text.Numeral.Grammar ( defaultInflection )
 import "numerals" Text.Numeral.Misc ( dec )
 import "this" Text.Numeral.Test ( TestData )

--- a/src-test/Text/Numeral/Language/LLD/TestData.hs
+++ b/src-test/Text/Numeral/Language/LLD/TestData.hs
@@ -17,7 +17,7 @@ module Text.Numeral.Language.LLD.TestData (cardinals) where
 -- Imports
 --------------------------------------------------------------------------------
 
-import "base" Prelude     ( Integral, (+) )
+import "base" Prelude     ( Integral, (+), (*) )
 import "numerals" Text.Numeral.Grammar
 import "numerals" Text.Numeral.Grammar ( defaultInflection )
 import "numerals" Text.Numeral.Misc ( dec )

--- a/src-test/Text/Numeral/Language/SPA/TestData.hs
+++ b/src-test/Text/Numeral/Language/SPA/TestData.hs
@@ -17,7 +17,7 @@ module Text.Numeral.Language.SPA.TestData (cardinals) where
 -- Imports
 --------------------------------------------------------------------------------
 
-import "base" Prelude ( (+), Integral )
+import "base" Prelude ( Integral, (+), (*) )
 import "numerals" Text.Numeral.Misc ( dec )
 import "numerals" Text.Numeral.Grammar
 import "numerals" Text.Numeral.Grammar ( defaultInflection )


### PR DESCRIPTION
Not sure if I did the right things so feedback very welcome!

## What

A few changes:

* Bumped the version in numerals.cabal
* added entry in changelog
* added dist-newstyle to .gitignore as I was using `cabal v2-build`
* fixed test build failures: it was complaining about `(*)` not being in scope, eg:

```
src-test/Text/Numeral/Language/LIT/TestData.hs:228:12: error: [GHC-88464]
    Variable not in scope: (*) :: t96 -> t97 -> i
    Suggested fix:
      Perhaps you want to add ‘*’ to the import list in the import of
      ‘Prelude’ (src-test/Text/Numeral/Language/LIT/TestData.hs:19:1-39).
    |
228 |       , (9 * dec 12, "devyni trilijonai")
```

## Why

Mainly because the current version that's [on hackage](https://hackage.haskell.org/package/numerals-0.4.1/dependencies) has fixed upper bounds.  This also closes #29 

## Testing

Tested locally note that some tests fail, including English ones:
```
$ cabal v2-build --enable-tests
./dist-newstyle/..../test-numerals
...
ENG:
  GB:
    unique data:
      cardinal:
      ordinal:
    cardinal:
      default:
        101: [Failed]
Expected 101 = "one hundred and one" but got "one hundred one"
        110: [Failed]
Expected 110 = "one hundred and ten" but got "one hundred ten"
        111: [Failed]
Expected 111 = "one hundred and eleven" but got "one hundred eleven"
....
         Properties  Test Cases  Total
 Passed  3           8099        8102
 Failed  0           332         332
 Total   3           8431        8434
```

## Benchmarking

```
$ cabal v2-bench
...
Running 1 benchmarks...
Benchmark bench-numerals: RUNNING...
benchmarking NLD
time                 93.50 μs   (93.19 μs .. 93.79 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 93.49 μs   (93.28 μs .. 93.77 μs)
std dev              821.4 ns   (639.2 ns .. 1.112 μs)
```

## Packaging

Ran `cabal v2-sdist` locally which produced:
```
$ cabal v2-sdist
Wrote tarball sdist to
..../numerals/dist-newstyle/sdist/numerals-0.4.2.tar.gz
```

I'm happy to upload it here but I think if you can, as maintainer it would be way, way better for you to do it 😄